### PR TITLE
Clarify RLB override for adding executable rules

### DIFF
--- a/Smepmp/Proposal.adoc
+++ b/Smepmp/Proposal.adoc
@@ -33,7 +33,7 @@ A _Shared-Region_ rule is *enforced* on all modes, with restrictions depending o
 * The encoding ``pmpcfg.LRWX=1111`` can be used for sharing data between M-mode and S/U mode, where both modes only have read-only access to the region. The rule remains *locked* so that any further modifications to its associated configuration or address registers are ignored until a *PMP reset*, unless ``mseccfg.RLB`` is set.
 
 
-.. Adding a rule with executable privileges that either is *M-mode-only* or a *locked* *Shared-Region* is not possible and such ``pmpcfg`` writes are ignored, leaving ``pmpcfg`` unchanged. This restriction can be temporarily lifted e.g. during the boot process, by setting ``mseccfg.RLB``.
+.. Adding a rule with executable privileges that either is *M-mode-only* or a *locked* *Shared-Region* is not possible and such ``pmpcfg`` writes are ignored, leaving ``pmpcfg`` unchanged. This restriction can be temporarily lifted by setting ``mseccfg.RLB`` e.g. during the boot process.
 
 .. Executing code with Machine mode privileges is only possible from memory regions with a matching *M-mode-only* rule or a *locked* *Shared-Region* rule with executable privileges. Executing code from a region without a matching rule or with a matching _S/U-mode-only_ rule is *denied*.
 


### PR DESCRIPTION
The new wording makes it clear RLB overrides the behaviour that prevents
M-mode only or locked Shared regions with executable privleges being
rather than that just being part of the example.